### PR TITLE
update office.js reference

### DIFF
--- a/addins/cfsample2/sharedapp.html
+++ b/addins/cfsample2/sharedapp.html
@@ -5,7 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 		<meta http-equiv="Expires" content="0" />
 		<title>Custom Functions Upgrade Test</title>
-		<script src="https://unpkg.com/@microsoft/office-js@1.1.26-custom.25/dist/office.debug.js" type="text/javascript"></script>
+		<script src="https://unpkg.com/@microsoft/office-js@1.1.27-custom.0/dist/office.debug.js" type="text/javascript"></script>
 		<script src="custom-functions.js" type="text/javascript"></script>
 		<script type="text/javascript">
 			var g_sharedAppData = {};


### PR DESCRIPTION
The office.js NPM package is generated by:
C:\Office\dev\otools\inc\osfclient\publish-tools>prepare-files usedefaults skiploc usereleasetype beta usehost excel useosfwebfiles local usecustomfunctionsandbundlesfiles local  usewarehousepath %USERPROFILE%\Desktop\warehouse2
